### PR TITLE
profiled_coordinator.hpp: check for RUSAGE_THREAD

### DIFF
--- a/libcaf_core/caf/scheduler/profiled_coordinator.hpp
+++ b/libcaf_core/caf/scheduler/profiled_coordinator.hpp
@@ -112,7 +112,11 @@ public:
       m.mem = 0;
 #     else
       ::rusage ru;
+#ifdef RUSAGE_THREAD
       ::getrusage(RUSAGE_THREAD, &ru);
+#else
+      ::getrusage(RUSAGE_SELF, &ru)
+#endif
       m.usr = to_usec(ru.ru_utime);
       m.sys = to_usec(ru.ru_stime);
       m.mem = ru.ru_maxrss;


### PR DESCRIPTION
RUSAGE_THREAD is not defined on uclibc, so use RUSAGE_SELF if
RUSAGE_THREAD is undefined

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>