### PR TITLE
Fix build on OpenBSD: setsockopt(2) has no SO_NOSIGPIPE

### DIFF
--- a/libcaf_net/caf/net/network_socket.cpp
+++ b/libcaf_net/caf/net/network_socket.cpp
@@ -43,7 +43,7 @@ uint16_t port_of(sockaddr& what) {
 
 namespace caf::net {
 
-#if defined(CAF_MACOS) || defined(CAF_IOS) || defined(CAF_BSD)
+#if defined(CAF_MACOS) || defined(CAF_IOS) || (defined(CAF_BSD) && !defined(__OpenBSD__))
 #  define CAF_HAS_NOSIGPIPE_SOCKET_FLAG
 #endif
 


### PR DESCRIPTION
```
.../zeek-8.0.1/zeek-8.0.1/auxil/broker/caf/libcaf_net/src/network_socket.cpp:72:48: error: use of undeclared identifier 'SO_NOSIGPIPE'
   72 |                   setsockopt(x.id, SOL_SOCKET, SO_NOSIGPIPE, &value,
      |                                                ^
```

This is the only tweak required for CAF to work on OpenBSD, at least
when built as part of Zeek.

ajacoutot@ (@ajacoutot) wrote this patch in 2022 as the previous port maintainer.
